### PR TITLE
feat(workflow): add build to test workflow

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,0 +1,53 @@
+name: Run Speedlify without committing results
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout results
+        id: checkout-results
+        uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          ref: refs/heads/results
+          path: results
+
+      - name: Checkout speedlify
+        uses: actions/checkout@v4
+        with:
+          path: default
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version-file: 'default/.nvmrc'
+          cache-dependency-path: 'default/package-lock.json'
+
+      - name: Copy existing results
+        if: steps.checkout-results.outcome == 'success'
+        run: cp -r results/. default/_data
+
+      - name: Install npm dependencies
+        run: npm ci
+        working-directory: default
+
+      - name: Run test-pages
+        run: npm run test-pages
+        working-directory: default
+
+      - name: Upload results artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: results
+          path: default/_data/results
+
+      - name: Upload results-last-runs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: results-last-runs.json
+          path: default/_data/results-last-runs.json


### PR DESCRIPTION
This is the same as the build workflow, but it just runs without committing the changes to the `results` branch - so the data in that branch should be clean.