### PR TITLE
fix(workflow): turn on gh-pages cron

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,10 +1,15 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches:
-      - results
+  # TODO: pushes using `GITHUB_TOKEN` don't trigger push events - use a
+  # generated personal access token to cause the event to be automatically
+  # triggered.
+  # push:
+    # branches:
+      # - results
   workflow_dispatch:
+  schedule:
+    - cron: "7 7 * * 1" # At 07:07 on Monday - https://crontab.guru/#7_7_*_*_1
 
 jobs:
   deploy:


### PR DESCRIPTION
## What

Turns on the cron trigger for the workflow that generates the `gh-pages` branch, and turns off the trigger for the `results` branch.

## Why
Pushes that are from an action using the GITHUB_TOKEN do not trigger a push event - you need to set up a personal access token and use that instead[^1]. 

In the meantime, we can use the cron job to run an hour after the results workflow to get a more brittle but still effective solution.

[^1]: https://github.com/orgs/community/discussions/25702