### PR TITLE
fix: fix chartist dependency css path

### DIFF
--- a/assets/css.njk
+++ b/assets/css.njk
@@ -1,6 +1,6 @@
 ---
 permalink: style.css
 ---
-{% include "../node_modules/chartist/dist/chartist.css" %}
+{% include "../node_modules/chartist/dist/index.css" %}
 {% include "./style.css" %}
 {% include "./sparkline.css" %}


### PR DESCRIPTION
## What

Corrects the Chartist CSS filepath.

## Why

Chartist was updated in #4 - and the change to the CSS filepath wasn't updated at the same time. This corrects that.