### PR TITLE
fix: remove starter message

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -1,31 +1,6 @@
 ---
 layout: layout.njk
 ---
-{% starterMessage %}
-<div class="starter-message">
-	<style>
-	.starter-message {
-		background-color: hsla(0, 0%, 0%, .4);
-		border: 2px solid hsla(60, 100%, 2%, 1);
-		border-radius: .5em;
-		padding: 2rem;
-		margin: 2rem auto;
-		max-width: 40em;
-	}
-	.starter-message h3 {
-		margin-top: 0;
-	}
-	.starter-message ol {
-		margin: 0;
-	}
-	</style>
-	<h3>Quick Guide to Speedlify</h3>
-	<ol>
-		<li>Add your own URLs to test in a <code>_data/sites/*.js</code> configuration file. Look at the existing samples (Make sure you use <code>skip: false</code>). You can delete the existing ones after you’ve made your own</li>
-		<li>Remove this message from <code>index.njk</code></li>
-	</ol>
-</div>
-{% endstarterMessage %}
 <table class="leaderboard leaderboard-list">
 	<caption>Choose a category</caption>
 	<thead data-sr-only>


### PR DESCRIPTION
## What

Removes the starter instructions from the index page

## Why

They're instructions to get set up, no longer needed, and the instructions themselves said to remove them 👍 